### PR TITLE
fix(mobile): refactor expo setup to adapt expo-updates

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -17,6 +17,9 @@
       "bundleIdentifier": "ai.sixpm.app",
       "config": {
         "usesNonExemptEncryption": false
+      },
+      "entitlements": {
+        "com.apple.developer.applesignin": ["Default"]
       }
     },
     "android": {

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,3 +1,8 @@
+import '@formatjs/intl-locale/polyfill-force'
+import '@formatjs/intl-pluralrules/polyfill-force'
+import '@formatjs/intl-pluralrules/locale-data/en'
+import '@formatjs/intl-pluralrules/locale-data/vi'
+
 import '../global.css'
 
 import * as Sentry from '@sentry/react-native'

--- a/apps/mobile/index.js
+++ b/apps/mobile/index.js
@@ -1,6 +1,0 @@
-import '@formatjs/intl-locale/polyfill-force'
-import '@formatjs/intl-pluralrules/polyfill-force'
-import '@formatjs/intl-pluralrules/locale-data/en'
-import '@formatjs/intl-pluralrules/locale-data/vi'
-
-import 'expo-router/entry'

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@6pm/mobile",
-  "main": "index.js",
+  "main": "expo-router/entry",
   "version": "1.0.0",
   "scripts": {
     "start": "expo start -c",


### PR DESCRIPTION
Note:
Set `EXPO_USE_METRO_WORKSPACE_ROOT=0` on EAS for production build, this variable is only necessary on development.

https://github.com/expo/eas-cli/issues/2280#issuecomment-2183524390