### PR TITLE
fix(api): remove unique constraint on budgetId with period config

### DIFF
--- a/apps/api/prisma/migrations/20240901110039_remove_budget_period_uniqe_constraint/migration.sql
+++ b/apps/api/prisma/migrations/20240901110039_remove_budget_period_uniqe_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "BudgetPeriodConfig_budgetId_key";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -83,7 +83,7 @@ model BudgetPeriodConfig {
   endDate   DateTime?
 
   budget   Budget @relation(fields: [budgetId], references: [id], onDelete: Cascade)
-  budgetId String @unique
+  budgetId String
 }
 
 enum BudgetPeriodType {

--- a/packages/validation/src/prisma/index.ts
+++ b/packages/validation/src/prisma/index.ts
@@ -1036,21 +1036,11 @@ export const BudgetPeriodConfigOrderByWithRelationInputSchema: z.ZodType<Prisma.
   budget: z.lazy(() => BudgetOrderByWithRelationInputSchema).optional()
 }).strict();
 
-export const BudgetPeriodConfigWhereUniqueInputSchema: z.ZodType<Prisma.BudgetPeriodConfigWhereUniqueInput> = z.union([
-  z.object({
-    id: z.string(),
-    budgetId: z.string()
-  }),
-  z.object({
-    id: z.string(),
-  }),
-  z.object({
-    budgetId: z.string(),
-  }),
-])
+export const BudgetPeriodConfigWhereUniqueInputSchema: z.ZodType<Prisma.BudgetPeriodConfigWhereUniqueInput> = z.object({
+  id: z.string()
+})
 .and(z.object({
   id: z.string().optional(),
-  budgetId: z.string().optional(),
   AND: z.union([ z.lazy(() => BudgetPeriodConfigWhereInputSchema),z.lazy(() => BudgetPeriodConfigWhereInputSchema).array() ]).optional(),
   OR: z.lazy(() => BudgetPeriodConfigWhereInputSchema).array().optional(),
   NOT: z.union([ z.lazy(() => BudgetPeriodConfigWhereInputSchema),z.lazy(() => BudgetPeriodConfigWhereInputSchema).array() ]).optional(),
@@ -1060,6 +1050,7 @@ export const BudgetPeriodConfigWhereUniqueInputSchema: z.ZodType<Prisma.BudgetPe
   amount: z.union([ z.lazy(() => DecimalFilterSchema),z.union([z.number(),z.string(),z.instanceof(Decimal),z.instanceof(Prisma.Decimal),DecimalJsLikeSchema,]).refine((v) => isValidDecimalInput(v), { message: 'Must be a Decimal' }) ]).optional(),
   startDate: z.union([ z.lazy(() => DateTimeNullableFilterSchema),z.coerce.date() ]).optional().nullable(),
   endDate: z.union([ z.lazy(() => DateTimeNullableFilterSchema),z.coerce.date() ]).optional().nullable(),
+  budgetId: z.union([ z.lazy(() => StringFilterSchema),z.string() ]).optional(),
   budget: z.union([ z.lazy(() => BudgetRelationFilterSchema),z.lazy(() => BudgetWhereInputSchema) ]).optional(),
 }).strict());
 


### PR DESCRIPTION
This constraint causes new period configs not be able to created.