### PR TITLE
chore(api): add default .env.development

### DIFF
--- a/apps/api/.env.development
+++ b/apps/api/.env.development
@@ -1,0 +1,6 @@
+NODE_ENV="development"
+LOG_LEVEL="debug"
+TZ="UTC"
+DATABASE_PRISMA_URL="postgresql://postgres:postgres@localhost:5432/6pm"
+DATABASE_URL_NON_POOLING="postgresql://postgres:postgres@localhost:5432/6pm"
+SHADOW_DATABASE_URL="postgresql://postgres:postgres@localhost:5432/6pm-shadow"


### PR DESCRIPTION
Ensure API timezone matches the production serverless services for better development and debugging.
